### PR TITLE
Handle CallWithFlashbotsSignature returning non-JSONRPC error

### DIFF
--- a/flashbotsrpc.go
+++ b/flashbotsrpc.go
@@ -211,7 +211,7 @@ func (rpc *FlashbotsRPC) CallWithFlashbotsSignature(method string, privKey *ecds
 		return nil, err
 	}
 
-	if resp.ID != request.ID && resp.JSONRPC != request.JSONRPC {
+	if resp.ID != request.ID || resp.JSONRPC != request.JSONRPC {
 		// this means we got back JSON but not a valid JSONRPC response
 		return nil, fmt.Errorf("%w: invalid JSONRPC response (HTTP status code: %d)", ErrRelayErrorResponse, response.StatusCode)
 	}

--- a/flashbotsrpc.go
+++ b/flashbotsrpc.go
@@ -211,6 +211,11 @@ func (rpc *FlashbotsRPC) CallWithFlashbotsSignature(method string, privKey *ecds
 		return nil, err
 	}
 
+	if resp.ID != request.ID && resp.JSONRPC != request.JSONRPC {
+		// this means we got back JSON but not a valid JSONRPC response
+		return nil, fmt.Errorf("%w: invalid JSONRPC response (HTTP status code: %d)", ErrRelayErrorResponse, response.StatusCode)
+	}
+
 	if resp.Error != nil {
 		return nil, fmt.Errorf("%w: %s", ErrRelayErrorResponse, (*resp).Error.Message)
 	}


### PR DESCRIPTION
Currently, if the `CallWithFlashbotsSignature` receiver returns JSON that is neither a JSONRPC response or the `{"error":"some error"}` format, then `CallWithFlashbotsSignature` will return `nil, nil`.

This adds a new `TestCallWithFlashbotsSignature` that exhibits the issue, as well as a fix: after unmarshaling the  response, we check that the `id` and `jsonrpc` fields are set correctly, if they aren't we can assume that the response was non-JSONRPC (and was also not a `RelayErrorResponse` since that path was already checked as well.

This could happen if for example the relay returns a JSON payload alongside a HTTP error, so I included the HTTP status code in the returned error.